### PR TITLE
インクリメンタルサーチ機能の実装

### DIFF
--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -20,6 +20,17 @@ $(function() {
     search_result.append(html);
   }
 
+  function  addUser(name, id){
+    var html = `
+            <div class='chat-group-user'>
+              <input name='group[user_ids][]' type='hidden' value='${id}'>
+              <p class='chat-group-user__name'>${name}</p></p>
+              <a class='user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn'>削除</a>
+            </div>
+            `
+    $('#chat-group-users').append(html)
+  };
+
   $('#user-search-field').on('keyup', function(){
     var input = $('#user-search-field').val();
     $.ajax({
@@ -43,5 +54,12 @@ $(function() {
     .fail(function() {
       alert("ユーザー検索に失敗しました");
     });
+  });
+
+  $(document).on('click', '.chat-group-user__btn--add', function(){
+    var userName = $(this).attr('data-user-name');
+    var userId = $(this).attr('data-user-id');
+    addUser(userName, userId);
+    $(this).parent().remove();
   });
 });

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -27,7 +27,7 @@ $(function() {
               <p class='chat-group-user__name'>${name}</p></p>
               <a class='user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn'>削除</a>
             </div>
-            `
+            `;
     $('#chat-group-users').append(html)
   };
 

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -1,0 +1,11 @@
+$(function() {
+  $('#user-search-field').on('keyup', function(){
+    var input = $('#user-search-field').val();
+    $.ajax({
+      type: 'GET',
+      url: '/users',
+      data: { keyword: input },
+      dataType: 'json'
+    })
+  });
+});

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -10,7 +10,6 @@ $(function() {
               </div>
               `
     search_result.append(html);
-    console.log(html);
   }
 
   function FormNoUser() {
@@ -19,7 +18,6 @@ $(function() {
               <p class="chat-group-user__name">ユーザーが見つかりません</p>
               </div>`
     search_result.append(html);
-    console.log(html);
   }
 
   $('#user-search-field').on('keyup', function(){

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -2,21 +2,21 @@ $(function() {
 
   var search_result = $('#user-search-result')
 
-  function appendUser(user) {
+  function hitUser(user) {
     var html =`
               <div class='chat-group-user clearfix'>
                 <p class='chat-group-user__name'>${user.name}</p>
-                <div class='user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="${user.id}" data-user-name="${user.name}">追加</div>
+                <a class='user-search-add chat-group-user__btn chat-group-user__btn--add' data-user-id='${user.id}' data-user-name='${user.name}'>追加</a>
               </div>
-              `
+              `;
     search_result.append(html);
   }
 
-  function FormNoUser() {
+  function hitNoUser() {
     var html =`
-              <div class="chat-group-user clearfix">
-              <p class="chat-group-user__name">ユーザーが見つかりません</p>
-              </div>`
+              <div class='chat-group-user clearfix'>
+              <p class='chat-group-user__name'>ユーザーが見つかりません</p>
+              </div>`;
     search_result.append(html);
   }
 
@@ -32,12 +32,12 @@ $(function() {
       search_result.empty();
       if (users.length !== 0) {
         users.forEach(function(user) {
-          appendUser(user);
+          hitUser(user);
         });
       } else if (input.length == 0) {
         return false;
       } else {
-        FormNoUser();
+        hitNoUser();
       }
     })
     .fail(function() {

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -1,4 +1,27 @@
 $(function() {
+
+  var search_result = $('#user-search-result')
+
+  function appendUser(user) {
+    var html =`
+              <div class='chat-group-user clearfix'>
+                <p class='chat-group-user__name'>${user.name}</p>
+                <div class='user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="${user.id}" data-user-name="${user.name}">追加</div>
+              </div>
+              `
+    search_result.append(html);
+    console.log(html);
+  }
+
+  function FormNoUser() {
+    var html =`
+              <div class="chat-group-user clearfix">
+              <p class="chat-group-user__name">ユーザーが見つかりません</p>
+              </div>`
+    search_result.append(html);
+    console.log(html);
+  }
+
   $('#user-search-field').on('keyup', function(){
     var input = $('#user-search-field').val();
     $.ajax({
@@ -7,5 +30,20 @@ $(function() {
       data: { keyword: input },
       dataType: 'json'
     })
+    .done(function(users) {
+      search_result.empty();
+      if (users.length !== 0) {
+        users.forEach(function(user) {
+          appendUser(user);
+        });
+      } else if (input.length == 0) {
+        return false;
+      } else {
+        FormNoUser();
+      }
+    })
+    .fail(function() {
+      alert("ユーザー検索に失敗しました");
+    });
   });
 });

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -62,4 +62,9 @@ $(function() {
     addUser(userName, userId);
     $(this).parent().remove();
   });
+
+  $(document).on('click', '.js-remove-btn', function(){
+    $(this).parent().remove();
+  });
+
 });

--- a/app/assets/stylesheets/_index-sidebar.scss
+++ b/app/assets/stylesheets/_index-sidebar.scss
@@ -27,7 +27,9 @@
     }
   }
   .groups {
+    height: calc( 100vh - 100px);
     padding: 0 20px;
+    overflow: scroll;
     .group {
       padding: 20px 0;
       a {

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,8 @@
 class UsersController < ApplicationController
 
   def index
+    return nil if params[:keyword] == ""
+    @users = User.where(['name LIKE ?', "%#{params[:keyword]}%"] ).where.not(id: current_user.id).limit(10)
     respond_to do |format|
       format.html
       format.json

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,12 @@
 class UsersController < ApplicationController
 
+  def index
+    respond_to do |format|
+      format.html
+      format.json
+    end
+  end
+
   def edit
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,6 @@ class UsersController < ApplicationController
     return nil if params[:keyword] == ""
     @users = User.where(['name LIKE ?', "%#{params[:keyword]}%"] ).where.not(id: current_user.id).limit(10)
     respond_to do |format|
-      format.html
       format.json
     end
   end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -11,14 +11,19 @@
     .chat-group-form__field--right
       = f.text_field :name, class: "chat__group__name chat-group-form__input", placeholder: "グループ名を入力してください"
   .chat-group-form__field
-    / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
-  .chat-group-form__field
     .chat-group-form__field--left
-      = f.label "チャットメンバー", class: "chat-group-form__label"
+      %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
     .chat-group-form__field--right
-      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-      = f.collection_check_boxes :user_ids, User.all, :id, :name
-      / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
+      .chat-group-form__search.clearfix
+        %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
+      #user-search-result
+
+  .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+      %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
+    .chat-group-form__field--right
+      #chat-group-users.js-add-user
+
   .chat-group-form__field
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -22,7 +22,19 @@
     .chat-group-form__field--left
       %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
+
       #chat-group-users.js-add-user
+        .chat-group-user.clearfix.js-chat-member
+          %input{name: 'group[user_ids][]', type: 'hidden', value: current_user.id}
+          %p.chat-group-user__name= current_user.name
+        - group.users.each do |user|
+          - if current_user.name != user.name
+            .chat-group-user.clearfix.js-chat-member
+              %input{name: 'group[user_ids][]', type: 'hidden', value: user.id}
+              %p.chat-group-user__name
+                = user.name
+              %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn
+                削除
 
   .chat-group-form__field
     .chat-group-form__field--left

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+  json.id user.id
+  json.name user.name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "groups#index"
-  resources :users, only: [:edit, :update]
+  resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
   end


### PR DESCRIPTION
# What
グループ作成時、グループに追加するユーザーの名前をインクリメンタルサーチで検索できるようにした。
検索したユーザー名は[追加]ボタンからグループのユーザーに追加でき、追加後のユーザーも[削除]ボタンから削除できるようにした。
また、カレントユーザーは最初からメンバーに表示させ、削除されないようにした。

# Why
従来のチェックボックスの場合、ユーザーが増えた時に追加したいユーザーをチェックボックスの一覧から探す必要があり非効率だった。
インクリメンタルサーチを利用した場合、追加したいユーザーがわかっていれば検索によりすぐに追加できるようになる。