### PR TITLE
メッセージの自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -65,4 +65,24 @@ $(function(){
     })
   })
 
+  var reloadMessages = function() {
+    last_message_id = $('.message:last').data('message-id');
+    $.ajax({
+      url: "api/messages",
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      var insertHTML = '';
+      $.each(messages, function(i, message) {
+        insertHTML += buildHTML(message)
+      });
+      $('.messages').append(insertHTML);
+    })
+    .fail(function() {
+      console.log("error");
+    });
+  };
+  setInterval(reloadMessages, 7000);
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -74,11 +74,16 @@ $(function(){
       data: {id: last_message_id}
     })
     .done(function(messages) {
-      var insertHTML = '';
-      $.each(messages, function(i, message) {
-        insertHTML += buildHTML(message)
-      });
-      $('.messages').append(insertHTML);
+      if(messages.length !== 0) {
+        var insertHTML = '';
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+        $('.messages').append(insertHTML);
+        $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+        $('#new_message')[0].reset();
+        $('.form__submit').prop('disabled', false);
+      }
     })
     .fail(function() {
       console.log("error");

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -89,5 +89,8 @@ $(function(){
       console.log("error");
     });
   };
-  setInterval(reloadMessages, 7000);
+  
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,44 +1,46 @@
 $(function(){
+
   function buildHTML(message) {
-    if( message.image ) {
-      var html = 
-      `<div class='message'>
-        <div class='message__upper-info'>
-          <div class='message__upper-info__talker'>
-            ${message.user_name}
-          </div>
-          <div class='message__upper-info__date'>
-            ${message.created_at}
-          </div>
+    var htmlUpper =
+    `<div class="message" data-message-id=${message.id} >
+      <div class="message__upper-info">
+        <div class="message__upper-info__talker">
+          ${message.user_name}
         </div>
-        <div class='message__lower'>
-          <p class='message__lower__text'>
-            ${message.message}
-          </p>
-          <img class="message__lower__image" src=${message.image}>
+        <div class="message__upper-info__date">
+          ${message.created_at}
         </div>
       </div>`
-      return html;
-    } else {
+    if( message.message && message.image) {
+      var html = 
+      htmlUpper +
+      `<div class='message__lower'>
+        <p class='message__lower__text'>
+          ${message.message}
+        </p>
+        <img class="message__lower__image" src=${message.image}>
+      </div>
+    </div>`
+    } else if (message.message) {
       var html =
-       `<div class='message'>
-          <div class='message__upper-info'>
-            <div class='message__upper-info__talker'>
-              ${message.user_name}
-            </div>
-            <div class='message__upper-info__date'>
-              ${message.created_at}
-            </div>
-          </div>
-          <div class='message__lower'>
-            <p class='message__lower__text'>
-              ${message.message}
-            </p>
-          </div>
-        </div>`
-      return html;
+      htmlUpper +
+      `<div class='message__lower'>
+        <p class='message__lower__text'>
+          ${message.message}
+        </p>
+      </div>
+    </div>`
+    } else if (message.image) {
+      var html =
+      htmlUpper +
+      `<div class='message__lower'>
+        <img class="message__lower__image" src=${message.image}>
+      </div>
+    </div>`
     };
-  }
+    return html;
+  };
+
   $('#new_message').on('submit', function(e) {
     e.preventDefault();
     var formData = new FormData(this);
@@ -62,4 +64,5 @@ $(function(){
       alert("メッセージ送信に失敗しました");
     })
   })
-})
+
+});

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -86,10 +86,10 @@ $(function(){
       }
     })
     .fail(function() {
-      console.log("error");
+      alert("自動更新に失敗しました");
     });
   };
-  
+
   if (document.location.href.match(/\/groups\/\d+\/messages/)) {
     setInterval(reloadMessages, 7000);
   }

--- a/app/controllers/api/messages/index.json.jbuilder
+++ b/app/controllers/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.message
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,5 +1,5 @@
 json.array! @messages do |message|
-  json.content message.message
+  json.message message.message
   json.image message.image.url
   json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
   json.user_name message.user.name

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {message: {id: message.id}}}
   .message__upper-info
     .message__upper-info__talker
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.user_name @message.user.name
 json.created_at @message.created_at.strftime("%Y/%m/%d(%a) %T")
 json.message @message.message
 json.image @message.image_url
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,9 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# What
チャットグループのメッセージ表示を７秒ごとに自動更新するようにした。
チャットのメッセージにカスタムデータ属性のメッセージidをつけ、７秒ごとにサーバーを確認、最後のメッセージより新しい差分メッセージがある場合にはチャット画面に表示させるようにした。

# Why
現在の仕様だと他のユーザーが投稿したメッセージはページをリロードするまで別のユーザーが確認できないため。
手動更新をしなくても画面が更新されることがユーザーがチャットアプリに求めている機能のため。